### PR TITLE
[86ent27y6] chore: add db in commit message types

### DIFF
--- a/kodkod/pre_commit_hooks/check_commit_message.py
+++ b/kodkod/pre_commit_hooks/check_commit_message.py
@@ -3,14 +3,19 @@ import sys
 
 
 def main() -> int:
-
-    with open(".git/COMMIT_EDITMSG", 'r') as file:
+    with open(".git/COMMIT_EDITMSG", "r") as file:
         first_line = file.readline().strip()
     # Define the regex pattern for checking the commit message
-    pattern = r'^(\[\w{9}\])+ (feat|chore|fix|ci|refactor|test|style|build|docs)(\(\w*\))?!?: .'
+    pattern = r"^(\[\w{9}\])+ (feat|chore|fix|ci|refactor|test|style|build|docs|db)(\(\w*\))?!?: ."
     if not re.match(pattern, first_line):
-        print("Commit message should have ClickUp ticket id and types(feat|chore|fix|ci|refactor|test|style|build|docs).", file=sys.stderr)
-        print("Please follow https://www.conventionalcommits.org/en/v1.0.0/", file=sys.stderr)
+        print(
+            "Commit message should have ClickUp ticket id and types(feat|chore|fix|ci|refactor|test|style|build|docs|db).",
+            file=sys.stderr,
+        )
+        print(
+            "Please follow https://www.conventionalcommits.org/en/v1.0.0/",
+            file=sys.stderr,
+        )
         print("Required format:", file=sys.stderr)
         print("    [ticketid] feat: commit message", file=sys.stderr)
         print("    [ticketid] feat!: breaking change", file=sys.stderr)
@@ -20,5 +25,6 @@ def main() -> int:
 
     return 0
 
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    exit(main())


### PR DESCRIPTION
<!--
  ** 原則上一個 PR 對應一個 ClickUp 的 Ticket **

  標題格式：
    [ClickUp號碼] 改動內容
  標題範例：
    [qwerasdf] 改動內容
    [qwerasdf] [asdfzxcv] 但如果兩筆 PR 高度相關可以放一起
    chore: 調整系統環境
    docs: 新增或更新文件
    refactor: 優化或重構程式碼
    hotfix: hotfix
    ci: ci
-->

## 改動原因/目的

ClickUp: #86ent27y6

新增 db 的選項在 commit message types

<!-- 如果有相關的外部原因請一併說明 -->

## 改動內容

新增 db 的選項在 commit message types

<!-- 不需要講解程式碼，如果程式碼難度到需要講解那你需要的是寫註解。 -->
<!-- Root Cause -->
<!-- How To Fix -->
<!-- Before / After Screenshot -->

## 確認事項
- [x] 是否修改共用元件
- [ ] 是否 Commit 這次 Scope 以外的 Code
